### PR TITLE
Fix/reveal motion tuning

### DIFF
--- a/.codex/skills/caveman/SKILL.md
+++ b/.codex/skills/caveman/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: caveman
+description: Use when user wants ultra-brief, token-efficient replies without losing technical accuracy, including phrases like "caveman mode", "talk like caveman", "use caveman", "less tokens", "save tokens", "be brief", or "$caveman".
+---
+
+# Caveman
+
+## Overview
+
+Ultra-compressed communication mode. Max signal, min tokens. Keep technical accuracy. Kill filler, not meaning.
+
+Do not roleplay stupidity. Sound terse, not dumb. If brevity conflicts with correctness, keep correctness.
+
+## Activation
+
+If triggered, stay in caveman mode for every later response in this thread.
+
+Do not drift back to normal voice.
+
+Turn off only when user says `stop caveman` or `normal mode`.
+
+## Rules
+
+- Drop articles, filler, pleasantries, and weak hedging.
+- Fragments OK.
+- Prefer short words and common abbreviations: `DB`, `auth`, `config`, `req`, `res`, `fn`, `impl`.
+- Strip weak conjunctions when meaning survives.
+- Use arrows for causality: `X -> Y`.
+- One word if one word enough.
+- Keep technical terms exact.
+- Keep code blocks unchanged.
+- Keep commands, flags, paths, env vars, versions, API names, and quoted errors exact.
+- Never compress away warnings, caveats, or required constraints.
+
+Default pattern:
+
+`[thing] [action] [reason]. [next step].`
+
+## Examples
+
+User: Why React component re-render?
+
+Answer:
+
+> Inline obj prop -> new ref -> re-render. `useMemo`.
+
+User: Explain database connection pooling.
+
+Answer:
+
+> Pool = reuse DB conn. Skip handshake -> faster under load.
+
+## Auto-Clarity Exception
+
+Temporarily switch to clear standard prose for:
+
+- security warnings
+- irreversible or destructive action confirmations
+- multi-step instructions where fragment order could confuse
+- cases where user asks to clarify or repeats question
+
+After clear section, resume caveman immediately.
+
+Example:
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+>
+> Caveman resume. Verify backup exist first.

--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ npm run dev
 │   │   ├── useSwipe.ts        # Touch swipe detection
 │   │   ├── useLightbox.ts     # Lightbox open/close/navigate state
 │   │   ├── useIntersection.ts # IntersectionObserver wrapper
+│   │   ├── useProgressiveReveal.ts # Fail-open motion for cards/previews
 │   │   └── useMediaQuery.ts   # Responsive breakpoint boolean
 │   ├── lib/
 │   │   ├── portfolio-config.ts  # Typed project config loader (Zod-validated at build time)
 │   │   ├── portfolio-schemas.ts # Zod schemas for photography / video / social-media
 │   │   ├── scaffold-project.ts  # Pure logic for create-project CLI
 │   │   ├── image-utils.ts       # WebP URL helpers (thumb/md/lg)
+│   │   ├── reveal-config.ts     # Central motion tuning tokens
+│   │   ├── reveal-helpers.ts    # Web Animations reveal helpers
 │   │   └── constants.ts         # Site-wide constants
 │   ├── types/
 │   │   └── portfolio.ts         # TypeScript types for portfolio data
@@ -130,6 +133,7 @@ npm run dev
 │   └── validate-manifests.mjs # Build-time manifest checker
 ├── e2e/                       # Playwright end-to-end tests
 ├── docs/                      # Developer & contributor documentation
+│   ├── GLOSSARY.md
 │   ├── ARCHITECTURE.md
 │   ├── DEVELOPMENT.md
 │   ├── DEPLOYMENT.md
@@ -151,6 +155,7 @@ npm run dev
 | Document | Audience | Purpose |
 |----------|----------|---------|
 | [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md) | **New developers** | Complete beginner's guide — zero-knowledge intro to the tech stack, first-time setup, and day-to-day workflow |
+| [docs/GLOSSARY.md](docs/GLOSSARY.md) | Everyone | Shared vocabulary for repo-specific terms, motion patterns, and gallery concepts |
 | [docs/REQUIREMENTS.md](docs/REQUIREMENTS.md) | Developers / PMs | Functional and non-functional requirements; deferred items |
 | [docs/DESIGN.md](docs/DESIGN.md) | Developers | Detailed software design: modules, data model, algorithms, security, testing |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Developers | Component hierarchy, data flow, image pipeline, PHP endpoints |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ globals.css                         (unlayered — always wins)
   ├── Font faces + CSS custom properties (design tokens)
   ├── Base reset / typography / container
   ├── Section backgrounds (full-bleed escape technique)
-  ├── Scroll-reveal animations ([data-reveal-ready])
+  ├── Fail-open motion notes (WAAPI-driven helpers live in TS)
   ├── Cross-component hover transforms
   ├── Selection mode + :has() pseudo-class rules
   ├── Reduced-motion + mobile global overrides
@@ -139,7 +139,7 @@ Homepage (src/app/page.tsx)
 │   ├─ GalleryGrid        — portrait images span 2 grid rows with blurred bg fill
 │   └─ Lightbox           — keyboard/swipe nav (Esc/←/→); createPortal to document.body
 ├─ FeaturedSection        — video project cards (with CardSlideshow) + IG previews
-│   └─ CardSlideshow      — auto-cycles previewImages; staggered by prime offset (see below)
+│   └─ CardSlideshow      — auto-cycles previewImages with per-card randomised timing
 ├─ AboutSection           — avatar, bilingual bio
 └─ ContactSection
     └─ ContactForm        — AJAX, CSRF, sessionStorage drafts
@@ -175,24 +175,40 @@ Social media project page (src/app/portfolio/social-media/[slug]/page.tsx)
 |------|------|---------|
 | `useSwipe` | `src/hooks/useSwipe.ts` | Detects touch swipe direction (left/right). Threshold: 50px, ignores vertical-dominated swipes. |
 | `useLightbox` | `src/hooks/useLightbox.ts` | Manages lightbox open/close/index state. Handles keyboard events (arrows, Escape). |
-| `useIntersection` | `src/hooks/useIntersection.ts` | Wraps `IntersectionObserver`. Used for lazy-loading YouTube embeds and image preloading. |
+| `useIntersection` | `src/hooks/useIntersection.ts` | Wraps `IntersectionObserver`. Used for lazy-loading YouTube embeds. |
 | `useMediaQuery` | `src/hooks/useMediaQuery.ts` | Returns `boolean` for a media query string. Used for mobile-vs-desktop nav behaviour. |
+| `useProgressiveReveal` | `src/hooks/useProgressiveReveal.ts` | Fail-open reveal hook for cards/previews. Content stays visible even if observer timing fails. |
+
+---
+
+## Fail-open motion
+
+The site now uses a **fail-open motion model**:
+
+- Cards and previews are visible by default
+- JavaScript adds motion as progressive enhancement
+- Visibility never depends on an observer callback
+
+This rule was added after Mobile Safari exposed a brittle failure mode in the old hide-then-show approach: masonry and image layout could settle after the first reveal pass, leaving some items loaded but still visually hidden.
+
+Current split:
+
+- `RevealGrid` + `useProgressiveReveal` provide **progressive reveal** for project cards, social previews, and similar teaser content near the viewport
+- `GalleryGrid` and `GallerySelection` use **load-triggered reveal** when their images finish loading, which is safer for masonry and CSS-column layouts
+
+Tuning values live in [src/lib/reveal-config.ts](/Users/florianewald/Documents/01_git_projects/Jinee-website-nodejs/src/lib/reveal-config.ts).
 
 ---
 
 ## CardSlideshow — stagger algorithm
 
-`src/components/gallery/CardSlideshow.tsx` uses a **prime-step module-level counter** to ensure all visible cards cycle independently:
+`src/components/gallery/CardSlideshow.tsx` gives each card its own randomised cycle interval and start delay on mount.
 
-```
-offset = (instanceCounter++ × 997) mod 4000  ms
-```
+- Base cycle: `SLIDESHOW_CYCLE_MS`
+- Extra jitter range: `SLIDESHOW_JITTER_MS`
+- Result: visible cards do not flip in lockstep
 
-- Cycle length: **4000 ms** per image
-- Step: **997 ms** — prime, so `gcd(997, 4000) = 1`
-- Result: 4000 unique phase offsets before any wrap-around; no two cards share a phase
-
-Why this matters: a naive 3-bucket scheme (0 / 1333 / 2667 ms) caused every 4th card to be in-phase with card 0, so groups of cards visibly flipped together. The prime step eliminates this entirely.
+Why this matters: synchronized card flips look mechanical and distract from the content. Randomised timing keeps the page feeling quieter and more editorial.
 
 Portrait images inside a slide are detected via `onLoad` measuring `naturalHeight > naturalWidth`. When detected, the slide switches to `object-fit: contain` and a CSS `::before` pseudo-element blurs the same image as a background fill — matching the lightbox portrait treatment.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -113,9 +113,9 @@ git push origin main           → GitHub Actions deploys out/ via FTP
 | `Navigation` | Client | `src/components/layout/` | Desktop submenu, mobile hamburger |
 | `Footer` | Server | `src/components/layout/` | Email, Calendly, legal links |
 | `CookieBanner` | Client | `src/components/layout/` | GDPR consent banner |
-| `GalleryGrid` | Client | `src/components/gallery/` | Responsive image grid; scroll-reveal via IntersectionObserver; portrait detection |
+| `GalleryGrid` | Client | `src/components/gallery/` | Responsive image grid; fail-open load-triggered tile motion; lightbox entry |
 | `GalleryWithLightbox` | Client | `src/components/gallery/` | Composes GalleryGrid + useLightbox + Lightbox |
-| `GalleryWithDownload` | Client | `src/components/gallery/` | Adds DownloadToolbar + GallerySelection + DownloadModal |
+| `GalleryWithDownload` | Client | `src/components/download/` | Adds DownloadToolbar + GallerySelection + DownloadModal |
 | `GallerySection` | Client | `src/components/sections/` | Slideshow + GalleryWithLightbox (homepage collage) |
 | `Lightbox` | Client | `src/components/gallery/` | Portal overlay; keyboard + swipe nav; portrait fill |
 | `Slideshow` | Client | `src/components/gallery/` | Full-image auto-advance strip |
@@ -123,10 +123,10 @@ git push origin main           → GitHub Actions deploys out/ via FTP
 | `VideoPlayer` | Client | `src/components/portfolio/` | Lazy YouTube embed via IntersectionObserver |
 | `ProjectCardsGrid` | Server | `src/components/portfolio/` | Category index grid (shared by photography + video) |
 | `ContactForm` | Client | `src/components/sections/` | AJAX form with CSRF, honeypot, sessionStorage draft |
-| `DownloadModal` | Client | `src/components/gallery/` | Password + CSRF → ZIP download |
-| `DownloadToolbar` | Client | `src/components/gallery/` | Select all, count, download button |
-| `RevealGrid` | Client | `src/components/portfolio/` | Scroll-triggered slide-in wrapper for project cards via IntersectionObserver |
-| `GallerySelection` | Client | `src/components/gallery/` | Checkbox overlay on GalleryGrid |
+| `DownloadModal` | Client | `src/components/download/` | Password + CSRF → ZIP download |
+| `DownloadToolbar` | Client | `src/components/download/` | Select all, count, download button |
+| `RevealGrid` | Client | `src/components/portfolio/` | Fail-open near-viewport motion wrapper for cards/previews |
+| `GallerySelection` | Client | `src/components/download/` | Checkbox overlay on GalleryGrid |
 
 ### 3.4 Custom hooks
 
@@ -136,6 +136,7 @@ git push origin main           → GitHub Actions deploys out/ via FTP
 | `useLightbox` | `src/hooks/useLightbox.ts` | Open/close/index; keyboard event listener. |
 | `useIntersection` | `src/hooks/useIntersection.ts` | `IntersectionObserver` wrapper. `once` mode for lazy loads. |
 | `useMediaQuery` | `src/hooks/useMediaQuery.ts` | SSR-safe boolean for a media query string. |
+| `useProgressiveReveal` | `src/hooks/useProgressiveReveal.ts` | Scroll/viewport motion for teaser content. Fail-open by design. |
 
 ---
 
@@ -272,12 +273,11 @@ RootLayout
 page.tsx  [Server]
 ├── Slideshow                [Client]  (if showSlideshow !== false)
 ├── GalleryWithLightbox      [Client]  (if !enableDownload)
-│   ├── GalleryGrid          [Server]
+│   ├── GalleryGrid          [Client]
 │   └── Lightbox             [Client, portal]
 └── GalleryWithDownload      [Client]  (if enableDownload)
     ├── DownloadToolbar      [Client]
     ├── GallerySelection     [Client]
-    │   └── GalleryGrid      [Server]
     ├── Lightbox             [Client, portal]
     └── DownloadModal        [Client]
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,7 +142,12 @@ For client-side interactivity (state, effects, browser APIs), add `'use client'`
 
 ### Gallery layout
 
-Photo galleries use `react-masonry-css` (shortest-column-first masonry). The `GalleryGrid` component renders images at their natural aspect ratio — no portrait detection or blur backgrounds. Breakpoints: 3 columns ≥900 px, 2 columns ≥480 px, 1 column below that.
+Photo galleries use two layouts:
+
+- `react-masonry-css` for standard masonry grids
+- CSS columns for some mixed-orientation galleries where browser balancing produces a steadier mobile result
+
+`GalleryGrid` renders images at their natural aspect ratio. Gallery tiles use load-triggered reveal: they stay visible by default and animate only after the image has loaded, which avoids Safari blank-row failures caused by hide-then-show reveal logic.
 
 The homepage collage images are configured in `src/content/portfolio/index-config.json` (`collageImages` array). Each entry requires `src`, `alt`, and `srcFull`.
 
@@ -164,6 +169,7 @@ the top. Use lower values (e.g. `20%`) to bias upward, higher values
 - **Global radius value:** set `--radius-site` in `src/app/globals.css` (derived: `--radius-sm`, `--radius-md`, `--radius-lg`).
 - **Homepage collage hover zoom:** adjust `transform: scale(1.1)` in `.gallery-cols .gallery-item:hover .gallery-img` in `src/app/globals.css`.
 - **Slideshow speed:** change `SLIDESHOW_CYCLE_MS` (minimum interval, default: 4000 ms) and `SLIDESHOW_JITTER_MS` (random extra range, default: 4000 ms) in `src/lib/constants.ts`. Each card picks a random interval between those two values on mount.
+- **Reveal motion:** tune `REVEAL_DURATION_MS`, `REVEAL_OFFSET_PX`, `REVEAL_EASING`, `REVEAL_BOTTOM_BUFFER_PX`, and `REVEAL_SIDE_BUFFER_PX` in `src/lib/reveal-config.ts`.
 - **About / Contact page theme:** change `ABOUT_PAGE_THEME` and `CONTACT_PAGE_THEME` in `src/lib/constants.ts`. Set either `"section-bg-charcoal"` (dark) or `"section-bg-white"` (light). Each constant controls its respective page independently.
 - **Social media grid columns:** change `SOCIAL_MEDIA_PREVIEW_COLUMNS` in `src/lib/constants.ts` (default: `5`). This controls how many cards are visible at once in each horizontal strip on the Social Media index page and the portfolio hub preview. The card width is computed from this value via a CSS custom property (`--sm-preview-cols`) using container query units (`cqi`), so no CSS edits are needed.
 - **Social media card mode:** toggle `SOCIAL_MEDIA_CARD_MODE` in `src/lib/constants.ts` (default: `true`). When `true`, each preview renders as a project card — portrait thumbnail on top, hashtags below in a card body. When `false`, only the thumbnail tile is shown. Applies to both the Social Media index page and the portfolio hub preview. Per-project hashtags are set via the `tags` string array in `src/content/portfolio/social-media.json`. Projects without a `tags` field show no body even when card mode is on.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,82 @@
+# Glossary
+
+Short repo terms. Fast sync. Less confusion.
+
+## Core architecture
+
+- `Static export`
+  Next.js App Router site built with `output: "export"`. Build writes pure files to `out/`. No Node.js server in production.
+
+- `PHP backend`
+  Small server-side layer in `backend/`. Handles contact form, download flow, CSRF, rate limiting, ZIP responses.
+
+- `Portfolio manifest`
+  JSON content files in `src/content/portfolio/`. Source of truth for project metadata and routing.
+
+- `images.json`
+  Per-project image manifest generated from `public/assets/**`. Gallery components read this file instead of hardcoding image lists.
+
+## UI / motion
+
+- `Fail-open motion`
+  Umbrella rule for motion in this repo. Content stays visible by default. Animation is enhancement only, never correctness gate.
+
+- `Progressive reveal`
+  Viewport-aware motion for teaser content like project cards and social previews.
+
+- `Load-triggered reveal`
+  Gallery motion model. Tile becomes animated when its image is loaded, not when a visibility observer fires.
+
+- `Fail-open`
+  Design rule: content must remain visible even if JS, image timing, or observer timing misbehaves. Opposite of old hide-then-show reveal.
+
+- `Reveal tokens`
+  Motion tuning values in [src/lib/reveal-config.ts](/Users/florianewald/Documents/01_git_projects/Jinee-website-nodejs/src/lib/reveal-config.ts): duration, offset, easing, viewport buffers.
+
+- `Viewport buffer`
+  Extra area around viewport used by reveal logic so cards can animate slightly before they fully enter view.
+
+- `WAAPI`
+  Web Animations API. Used for reveal motion in `animateRevealElement()` instead of CSS classes that hide content first.
+
+## Galleries
+
+- `Masonry`
+  `react-masonry-css` layout used for standard gallery grids. Columns filled shortest-first.
+
+- `CSS columns layout`
+  Browser-managed column flow used on some mixed-orientation galleries. Better balance for portrait/landscape mixes on narrow screens.
+
+- `GalleryGrid`
+  Main image grid component for photography galleries. Handles layout + progressive load animation.
+
+- `GallerySelection`
+  Download-mode gallery variant. Same visual grid, plus checkbox overlay and selection state.
+
+- `Lightbox`
+  Full-screen overlay for browsing gallery images, with keyboard and swipe navigation.
+
+- `CardSlideshow`
+  Small auto-cycling thumbnail preview used in portfolio cards.
+
+## Content
+
+- `Portfolio card`
+  Teaser card shown on index pages and homepage sections. Comes from `portfolioCard` data inside each project manifest.
+
+- `Project page`
+  Detail page for one photography, video, or social-media project.
+
+- `Homepage collage`
+  Curated travel image set on homepage. Configured in `src/content/portfolio/index-config.json`.
+
+## Styling
+
+- `Panda CSS`
+  Main styling system. Atomic classes generated from `css()` and `cx()`.
+
+- `globals.css`
+  Intentional global CSS. Holds tokens, reset, section context overrides, hover rules, and selectors that do not map cleanly to Panda.
+
+- `Design-decision comment`
+  Comment that explains why code is shaped this way, not only what it does. Use for non-obvious tradeoffs, browser workarounds, and safety rules.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -62,11 +62,11 @@ For the technical design see [DESIGN.md](DESIGN.md).
 
 | # | Item | Area | Status |
 |---|------|------|--------|
-| V-1 | Scroll-triggered slide-in for homepage collage images (`GalleryGrid` IntersectionObserver) | Animation | ✅ |
-| V-2 | Scroll-triggered slide-in for project cards (`RevealGrid`, already wired on photography/video index pages) | Animation | ✅ |
+| V-1 | Fail-open progressive reveal for teaser cards and previews (`RevealGrid` + `useProgressiveReveal`) | Animation | ✅ |
+| V-2 | Load-triggered gallery tile reveal for photo grids (`GalleryGrid` / `GallerySelection`) | Animation | ✅ |
 | V-3 | Border-radius preserved on gallery image hover (`will-change: transform` on `.gallery-item`) | Visual | ✅ |
 | V-4 | Removed `NO_RADIUS` global toggle from `layout.tsx` and `globals.css` | Cleanup | ✅ |
-| V-5 | Per-card unique slideshow stagger — `(cardIndex × 777) % 4000` — no two cards flip simultaneously | Animation | ✅ |
+| V-5 | Per-card randomised slideshow timing via cycle jitter + start delay | Animation | ✅ |
 | V-6 | Card slideshow fallback background changed from `#111` to `#f5f5f5` (no black flash before image loads) | Visual | ✅ |
 
 ---

--- a/docs/MIGRATION-PROGRESS.md
+++ b/docs/MIGRATION-PROGRESS.md
@@ -83,7 +83,7 @@ with pixel-perfect visual regression validation.
 | Font faces + design tokens + base reset | ~110 | Global foundation, CSS custom properties |
 | Container + links + typography | ~30 | @layer base rules, global selectors |
 | Section backgrounds (full-bleed) | ~20 | Used by 8+ components with complex descendant selectors |
-| Scroll-reveal animations | ~35 | `[data-reveal-ready]` attribute selectors, dynamic `.reveal--visible` class |
+| Progressive reveal motion | ~10 | Globals keep only notes/selectors; fail-open reveal logic moved to TS helpers/hooks |
 | Hover transforms + context selectors | ~30 | Cross-component descendant selectors (e.g. `.project-card:hover .project-card__thumb img`) |
 | Selection mode + checkbox `:has()` | ~20 | CSS `:has()` pseudo-class not supported in Panda |
 | Reduced motion + mobile overrides | ~25 | Global `@media` queries |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,37 +256,11 @@ section { margin-bottom: 0; padding-top: 0.5rem; padding-bottom: 0.5rem; }
    Scroll-reveal, hover transforms, and context-dependent selectors remain here.
    ══════════════════════════════════════════════════════════════════════════════ */
 
-/* ─── Scroll-reveal animation ───────────────────────────────────────────────
-   Items start hidden only once JS has set data-reveal-ready on the container.
-   IntersectionObserver then adds .reveal--visible when items scroll into view.
-   ──────────────────────────────────────────────────────────────────────────── */
-[data-reveal-ready] .gallery-item {
-  opacity: 0;
-  transform: translateY(22px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
-}
-[data-reveal-ready] .gallery-item.reveal--visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-[data-reveal-ready] .project-card {
-  opacity: 0;
-  transform: translateY(22px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
-}
-[data-reveal-ready] .project-card.reveal--visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-[data-reveal-ready] .instagram-preview {
-  opacity: 0;
-  transform: translateY(22px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
-}
-[data-reveal-ready] .instagram-preview.reveal--visible {
-  opacity: 1;
-  transform: translateY(0);
-}
+/* ─── Progressive reveal animation ─────────────────────────────────────────
+   Scroll-based motion is handled via the Web Animations API in
+   `useProgressiveReveal`. Content stays visible by default, so JS/layout
+   timing issues can't leave cards or gallery items hidden.
+   ────────────────────────────────────────────────────────────────────────── */
 
 /* ─── Context-dependent selectors (globals only) ────────────────────────── */
 a.project-card,
@@ -376,5 +350,4 @@ a.project-card:focus { color: var(--charcoal); text-decoration: none; }
 @media (max-width: 560px) {
   :root { --site-hero-mobile-height: 104px; }
 }
-
 

--- a/src/components/download/GallerySelection.tsx
+++ b/src/components/download/GallerySelection.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import Image from "next/image";
 import Masonry from "react-masonry-css";
 import { cx } from "@/styled-system/css";
+import { animateRevealElement } from "@/lib/reveal-helpers";
 import type { GalleryImage } from "@/components/gallery/Lightbox";
 import {
   projectGallery,
@@ -39,76 +41,104 @@ export default function GallerySelection({
   onImageClick,
   onSelectionChange,
 }: GallerySelectionProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const animateLoadedItems = () => {
+      container.querySelectorAll<HTMLImageElement>(".gallery-item img").forEach((img) => {
+        if (!img.complete) return;
+        const item = img.closest(".gallery-item");
+        if (item instanceof HTMLElement) animateRevealElement(item);
+      });
+    };
+
+    animateLoadedItems();
+    const timeoutId = window.setTimeout(animateLoadedItems, 400);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [images]);
+
+  function handleImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    const item = e.currentTarget.closest(".gallery-item");
+    if (item instanceof HTMLElement) animateRevealElement(item);
+  }
+
   return (
-    <Masonry
-      breakpointCols={BREAKPOINT_COLS}
-      className={cx(projectGallery, "project-gallery", selectionMode && "selection-mode")}
-      columnClassName={cx(projectGalleryCol, "project-gallery__col")}
-    >
-      {images.map((img, i) => {
-        const filename = toDownloadFilename(img.src);
-        const isChecked = selected.includes(filename);
+    <div ref={containerRef}>
+      <Masonry
+        breakpointCols={BREAKPOINT_COLS}
+        className={cx(projectGallery, "project-gallery", selectionMode && "selection-mode")}
+        columnClassName={cx(projectGalleryCol, "project-gallery__col")}
+      >
+        {images.map((img, i) => {
+          const filename = toDownloadFilename(img.src);
+          const isChecked = selected.includes(filename);
 
-        return (
-          <div key={`${img.src}-${i}`} className={cx(galleryItem, "gallery-item")}>
-            <button
-              className={cx(galleryItemTrigger, "gallery-item__trigger")}
-              onClick={() => {
-                if (selectionMode) {
-                  onSelectionChange(filename, !isChecked);
-                } else {
-                  onImageClick(i);
-                }
-              }}
-              aria-label={
-                selectionMode
-                  ? `${isChecked ? "Deselect" : "Select"} ${img.alt}`
-                  : `Open image: ${img.alt}`
-              }
-            >
-              <Image
-                src={img.src}
-                alt={img.alt}
-                width={800}
-                height={0}
-                loading="lazy"
-                className={cx(galleryImg, "gallery-img")}
-                unoptimized
-              />
-            </button>
-
-            {selectionMode && (
-              <label className={cx(galleryCheckbox, "gallery-checkbox")}>
-                <input
-                  type="checkbox"
-                  className={cx(inlineSelect, "inline-select")}
-                  aria-label={`Select ${img.alt} for download`}
-                  value={filename}
-                  checked={isChecked}
-                  onChange={(e) =>
-                    onSelectionChange(filename, e.target.checked)
+          return (
+            <div key={`${img.src}-${i}`} className={cx(galleryItem, "gallery-item")}>
+              <button
+                className={cx(galleryItemTrigger, "gallery-item__trigger")}
+                onClick={() => {
+                  if (selectionMode) {
+                    onSelectionChange(filename, !isChecked);
+                  } else {
+                    onImageClick(i);
                   }
-                  tabIndex={-1}
+                }}
+                aria-label={
+                  selectionMode
+                    ? `${isChecked ? "Deselect" : "Select"} ${img.alt}`
+                    : `Open image: ${img.alt}`
+                }
+              >
+                <Image
+                  src={img.src}
+                  alt={img.alt}
+                  width={800}
+                  height={0}
+                  loading="lazy"
+                  className={cx(galleryImg, "gallery-img")}
+                  unoptimized
+                  onLoad={handleImageLoad}
                 />
-                <svg
-                  className={cx(galleryCheckboxIcon, "gallery-checkbox-icon")}
-                  viewBox="0 0 22 22"
-                  fill="none"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M 3.5 11.5 L 8.5 16.5 L 19 5"
-                    stroke="#595959"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+              </button>
+
+              {selectionMode && (
+                <label className={cx(galleryCheckbox, "gallery-checkbox")}>
+                  <input
+                    type="checkbox"
+                    className={cx(inlineSelect, "inline-select")}
+                    aria-label={`Select ${img.alt} for download`}
+                    value={filename}
+                    checked={isChecked}
+                    onChange={(e) =>
+                      onSelectionChange(filename, e.target.checked)
+                    }
+                    tabIndex={-1}
                   />
-                </svg>
-              </label>
-            )}
-          </div>
-        );
-      })}
-    </Masonry>
+                  <svg
+                    className={cx(galleryCheckboxIcon, "gallery-checkbox-icon")}
+                    viewBox="0 0 22 22"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M 3.5 11.5 L 8.5 16.5 L 19 5"
+                      stroke="#595959"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </label>
+              )}
+            </div>
+          );
+        })}
+      </Masonry>
+    </div>
   );
 }

--- a/src/components/download/GallerySelection.tsx
+++ b/src/components/download/GallerySelection.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import Image from "next/image";
 import Masonry from "react-masonry-css";
 import { cx } from "@/styled-system/css";
-import { animateRevealElement } from "@/lib/reveal-helpers";
+import { animateRevealElement, isElementWithinRevealRange } from "@/lib/reveal-helpers";
+import { useLoadedGalleryReveal } from "@/hooks/useLoadedGalleryReveal";
 import type { GalleryImage } from "@/components/gallery/Lightbox";
 import {
   projectGallery,
@@ -42,28 +43,15 @@ export default function GallerySelection({
   onSelectionChange,
 }: GallerySelectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const animateLoadedItems = () => {
-      container.querySelectorAll<HTMLImageElement>(".gallery-item img").forEach((img) => {
-        if (!img.complete) return;
-        const item = img.closest(".gallery-item");
-        if (item instanceof HTMLElement) animateRevealElement(item);
-      });
-    };
-
-    animateLoadedItems();
-    const timeoutId = window.setTimeout(animateLoadedItems, 400);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [images]);
+  useLoadedGalleryReveal(containerRef);
 
   function handleImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    // Same fail-open rule as GalleryGrid: selection mode must stay usable even
+    // if timing is odd, so load can add motion but never gate visibility.
     const item = e.currentTarget.closest(".gallery-item");
-    if (item instanceof HTMLElement) animateRevealElement(item);
+    if (item instanceof HTMLElement && isElementWithinRevealRange(item)) {
+      animateRevealElement(item);
+    }
   }
 
   return (
@@ -97,8 +85,8 @@ export default function GallerySelection({
                 <Image
                   src={img.src}
                   alt={img.alt}
-                  width={800}
-                  height={0}
+                  width={img.width ?? 800}
+                  height={img.height ?? 0}
                   loading="lazy"
                   className={cx(galleryImg, "gallery-img")}
                   unoptimized

--- a/src/components/download/__tests__/GallerySelection.test.tsx
+++ b/src/components/download/__tests__/GallerySelection.test.tsx
@@ -2,9 +2,9 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import GallerySelection from "@/components/download/GallerySelection";
 
 const IMAGES = [
-  { src: "/img/a-800.webp", alt: "Photo A", srcFull: "/img/a-1600.webp" },
-  { src: "/img/b-800.webp", alt: "Photo B", srcFull: "/img/b-1600.webp" },
-  { src: "/img/c-800.webp", alt: "Photo C", srcFull: "/img/c-1600.webp" },
+  { src: "/img/a-800.webp", alt: "Photo A", srcFull: "/img/a-1600.webp", width: 800, height: 540 },
+  { src: "/img/b-800.webp", alt: "Photo B", srcFull: "/img/b-1600.webp", width: 800, height: 1200 },
+  { src: "/img/c-800.webp", alt: "Photo C", srcFull: "/img/c-1600.webp", width: 800, height: 533 },
 ];
 
 describe("GallerySelection", () => {
@@ -78,5 +78,21 @@ describe("GallerySelection", () => {
       screen.getByRole("img", { name: "Photo A" }).closest("button")!
     );
     expect(onImageClick).toHaveBeenCalledWith(0);
+  });
+
+  it("passes intrinsic width and height through to selection images", () => {
+    render(
+      <GallerySelection
+        images={IMAGES}
+        selectionMode={false}
+        selected={[]}
+        onImageClick={jest.fn()}
+        onSelectionChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Photo A" })).toHaveAttribute("width", "800");
+    expect(screen.getByRole("img", { name: "Photo A" })).toHaveAttribute("height", "540");
+    expect(screen.getByRole("img", { name: "Photo B" })).toHaveAttribute("height", "1200");
   });
 });

--- a/src/components/gallery/GalleryGrid.tsx
+++ b/src/components/gallery/GalleryGrid.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import Image from "next/image";
 import Masonry from "react-masonry-css";
 import { cx } from "@/styled-system/css";
-import { animateRevealElement } from "@/lib/reveal-helpers";
+import { animateRevealElement, isElementWithinRevealRange } from "@/lib/reveal-helpers";
+import { useLoadedGalleryReveal } from "@/hooks/useLoadedGalleryReveal";
 import type { GalleryImage } from "./Lightbox";
 import {
   projectGallery,
@@ -37,28 +38,15 @@ export default function GalleryGrid({
   useColumnsLayout = false,
 }: GalleryGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const animateLoadedItems = () => {
-      container.querySelectorAll<HTMLImageElement>(".gallery-item img").forEach((img) => {
-        if (!img.complete) return;
-        const item = img.closest(".gallery-item");
-        if (item instanceof HTMLElement) animateRevealElement(item);
-      });
-    };
-
-    animateLoadedItems();
-    const timeoutId = window.setTimeout(animateLoadedItems, 400);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [images]);
+  useLoadedGalleryReveal(containerRef);
 
   function handleImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    // Gallery tiles use image-load reveal, not viewport reveal, because the
+    // gallery must stay visible even if layout settles late on Safari.
     const item = e.currentTarget.closest(".gallery-item");
-    if (item instanceof HTMLElement) animateRevealElement(item);
+    if (item instanceof HTMLElement && isElementWithinRevealRange(item)) {
+      animateRevealElement(item);
+    }
   }
 
   if (images.length === 0) return null;
@@ -79,8 +67,8 @@ export default function GalleryGrid({
       <Image
         src={img.src}
         alt={img.alt}
-        width={800}
-        height={0}
+        width={img.width ?? 800}
+        height={img.height ?? 0}
         loading="lazy"
         className={cx(galleryImg, "gallery-img")}
         unoptimized

--- a/src/components/gallery/GalleryGrid.tsx
+++ b/src/components/gallery/GalleryGrid.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import Image from "next/image";
 import Masonry from "react-masonry-css";
 import { cx } from "@/styled-system/css";
+import { animateRevealElement } from "@/lib/reveal-helpers";
 import type { GalleryImage } from "./Lightbox";
 import {
   projectGallery,
@@ -34,6 +36,31 @@ export default function GalleryGrid({
   onImageClick,
   useColumnsLayout = false,
 }: GalleryGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const animateLoadedItems = () => {
+      container.querySelectorAll<HTMLImageElement>(".gallery-item img").forEach((img) => {
+        if (!img.complete) return;
+        const item = img.closest(".gallery-item");
+        if (item instanceof HTMLElement) animateRevealElement(item);
+      });
+    };
+
+    animateLoadedItems();
+    const timeoutId = window.setTimeout(animateLoadedItems, 400);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [images]);
+
+  function handleImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    const item = e.currentTarget.closest(".gallery-item");
+    if (item instanceof HTMLElement) animateRevealElement(item);
+  }
+
   if (images.length === 0) return null;
 
   const inColumns = useColumnsLayout;
@@ -59,20 +86,21 @@ export default function GalleryGrid({
         unoptimized
         style={{ height: "auto" }}
         {...(img.blur ? { placeholder: "blur" as const, blurDataURL: img.blur } : {})}
+        onLoad={handleImageLoad}
       />
     </button>
   ));
 
   if (useColumnsLayout) {
     return (
-      <div className={cx(galleryCols, "gallery-cols")}>
+      <div ref={containerRef} className={cx(galleryCols, "gallery-cols")}>
         {galleryItems}
       </div>
     );
   }
 
   return (
-    <div>
+    <div ref={containerRef}>
       <Masonry
         breakpointCols={BREAKPOINT_COLS}
         className={cx(projectGallery, "project-gallery")}

--- a/src/components/gallery/Lightbox.tsx
+++ b/src/components/gallery/Lightbox.tsx
@@ -106,6 +106,8 @@ export interface GalleryImage {
   alt: string;
   srcFull?: string;
   blur?: string;
+  width?: number;
+  height?: number;
 }
 
 interface LightboxProps {
@@ -352,4 +354,3 @@ export default function Lightbox({
     document.body
   );
 }
-

--- a/src/components/gallery/__tests__/GalleryGrid.test.tsx
+++ b/src/components/gallery/__tests__/GalleryGrid.test.tsx
@@ -22,9 +22,9 @@ jest.mock("react-masonry-css", () => ({
 }));
 
 const IMAGES = [
-  { src: "/img/a-800.webp", alt: "Photo A", srcFull: "/img/a-1600.webp" },
-  { src: "/img/b-800.webp", alt: "Photo B", srcFull: "/img/b-1600.webp" },
-  { src: "/img/c-800.webp", alt: "Photo C", srcFull: "/img/c-1600.webp" },
+  { src: "/img/a-800.webp", alt: "Photo A", srcFull: "/img/a-1600.webp", width: 800, height: 540 },
+  { src: "/img/b-800.webp", alt: "Photo B", srcFull: "/img/b-1600.webp", width: 800, height: 1200 },
+  { src: "/img/c-800.webp", alt: "Photo C", srcFull: "/img/c-1600.webp", width: 800, height: 533 },
 ];
 
 const GLOBALS_CSS = fs.readFileSync(
@@ -98,6 +98,14 @@ describe("GalleryGrid", () => {
     render(<GalleryGrid images={IMAGES} onImageClick={jest.fn()} useColumnsLayout />);
     expect(document.querySelector(".gallery-cols")).toBeInTheDocument();
     expect(screen.queryByTestId("masonry-grid")).toBeNull();
+  });
+
+  it("passes intrinsic width and height through to gallery images", () => {
+    render(<GalleryGrid images={IMAGES} onImageClick={jest.fn()} />);
+
+    expect(screen.getByRole("img", { name: "Photo A" })).toHaveAttribute("width", "800");
+    expect(screen.getByRole("img", { name: "Photo A" })).toHaveAttribute("height", "540");
+    expect(screen.getByRole("img", { name: "Photo B" })).toHaveAttribute("height", "1200");
   });
 
   it("keeps gallery items visible by default even before any reveal class is applied", () => {

--- a/src/components/gallery/__tests__/GalleryGrid.test.tsx
+++ b/src/components/gallery/__tests__/GalleryGrid.test.tsx
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { render, screen, fireEvent } from "@testing-library/react";
 import GalleryGrid from "@/components/gallery/GalleryGrid";
 
@@ -24,6 +26,18 @@ const IMAGES = [
   { src: "/img/b-800.webp", alt: "Photo B", srcFull: "/img/b-1600.webp" },
   { src: "/img/c-800.webp", alt: "Photo C", srcFull: "/img/c-1600.webp" },
 ];
+
+const GLOBALS_CSS = fs.readFileSync(
+  path.join(process.cwd(), "src/app/globals.css"),
+  "utf8"
+);
+
+beforeAll(() => {
+  const style = document.createElement("style");
+  style.setAttribute("data-testid", "globals-css");
+  style.textContent = GLOBALS_CSS;
+  document.head.appendChild(style);
+});
 
 describe("GalleryGrid", () => {
   it("renders a grid item for every image", () => {
@@ -84,5 +98,17 @@ describe("GalleryGrid", () => {
     render(<GalleryGrid images={IMAGES} onImageClick={jest.fn()} useColumnsLayout />);
     expect(document.querySelector(".gallery-cols")).toBeInTheDocument();
     expect(screen.queryByTestId("masonry-grid")).toBeNull();
+  });
+
+  it("keeps gallery items visible by default even before any reveal class is applied", () => {
+    render(
+      <div data-reveal-ready="">
+        <GalleryGrid images={IMAGES} onImageClick={jest.fn()} />
+      </div>
+    );
+
+    const firstItem = screen.getByRole("img", { name: "Photo A" }).closest("button");
+    expect(firstItem).not.toBeNull();
+    expect(window.getComputedStyle(firstItem!).opacity).not.toBe("0");
   });
 });

--- a/src/components/portfolio/RevealGrid.tsx
+++ b/src/components/portfolio/RevealGrid.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
+import { useProgressiveReveal } from "@/hooks/useProgressiveReveal";
 
 interface RevealGridProps {
   children: React.ReactNode;
   /** Optional CSS class applied to the wrapper div */
   className?: string;
-}
-
-const REVEAL_BOTTOM_BUFFER_PX = 160;
-const REVEAL_SIDE_BUFFER_PX = 50;
-
-function isWithinRevealRange(rect: DOMRect) {
-  return (
-    rect.top < window.innerHeight + REVEAL_BOTTOM_BUFFER_PX &&
-    rect.bottom > -REVEAL_BOTTOM_BUFFER_PX &&
-    rect.left < window.innerWidth + REVEAL_SIDE_BUFFER_PX &&
-    rect.right > -REVEAL_SIDE_BUFFER_PX
-  );
 }
 
 /**
@@ -27,42 +16,7 @@ function isWithinRevealRange(rect: DOMRect) {
  */
 export default function RevealGrid({ children, className }: RevealGridProps) {
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const container = ref.current;
-    if (!container) return;
-
-    const items = Array.from(
-      container.querySelectorAll<HTMLElement>(".project-card, .gallery-item, .instagram-preview")
-    );
-    if (!items.length) return;
-
-    // Pre-mark items already in viewport so they never jump on mount
-    items.forEach((item) => {
-      const rect = item.getBoundingClientRect();
-      if (isWithinRevealRange(rect)) {
-        item.classList.add("reveal--visible");
-      }
-    });
-    container.setAttribute("data-reveal-ready", "");
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            (entry.target as HTMLElement).classList.add("reveal--visible");
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        threshold: 0,
-        rootMargin: `0px ${REVEAL_SIDE_BUFFER_PX}px ${REVEAL_BOTTOM_BUFFER_PX}px ${REVEAL_SIDE_BUFFER_PX}px`,
-      }
-    );
-    items.forEach((item) => observer.observe(item));
-    return () => observer.disconnect();
-  }, []);
+  useProgressiveReveal(ref, ".project-card, .gallery-item, .instagram-preview");
 
   return (
     <div ref={ref} className={className}>

--- a/src/components/portfolio/RevealGrid.tsx
+++ b/src/components/portfolio/RevealGrid.tsx
@@ -10,13 +10,13 @@ interface RevealGridProps {
 }
 
 /**
- * Thin client wrapper that adds scroll-triggered slide-in animation to
- * .project-card and .gallery-item children via IntersectionObserver.
+ * Thin client wrapper that adds fail-open near-viewport motion to teaser
+ * content. Children stay visible by default; the observer only adds polish.
  * Keeps parent pages as Server Components.
  */
 export default function RevealGrid({ children, className }: RevealGridProps) {
   const ref = useRef<HTMLDivElement>(null);
-  useProgressiveReveal(ref, ".project-card, .gallery-item, .instagram-preview");
+  useProgressiveReveal(ref, ".project-card, .instagram-preview");
 
   return (
     <div ref={ref} className={className}>

--- a/src/components/portfolio/__tests__/RevealGrid.test.tsx
+++ b/src/components/portfolio/__tests__/RevealGrid.test.tsx
@@ -24,16 +24,33 @@ describe("RevealGrid", () => {
     expect(container.firstChild).toHaveClass("project-grid");
   });
 
-  it("sets data-reveal-ready after mount", () => {
+  it("does not gate visibility behind data-reveal-ready", () => {
     const { container } = render(
       <RevealGrid>
         <div className="project-card">card</div>
       </RevealGrid>
     );
-    expect(container.firstChild).toHaveAttribute("data-reveal-ready");
+    expect(container.firstChild).not.toHaveAttribute("data-reveal-ready");
   });
 
-  it("observes .project-card children", () => {
+  it("observes out-of-range .project-card children for progressive animation", () => {
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(
+        () =>
+          ({
+            top: 2000,
+            bottom: 2200,
+            left: 0,
+            right: 200,
+            width: 200,
+            height: 200,
+            x: 0,
+            y: 2000,
+            toJSON: () => ({}),
+          }) as DOMRect
+      );
+
     render(
       <RevealGrid>
         <a className="project-card">Card 1</a>

--- a/src/hooks/__tests__/useLoadedGalleryReveal.test.tsx
+++ b/src/hooks/__tests__/useLoadedGalleryReveal.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useRef } from "react";
+import { useLoadedGalleryReveal } from "@/hooks/useLoadedGalleryReveal";
+
+function TestGallery() {
+  const ref = useRef<HTMLDivElement>(null);
+  useLoadedGalleryReveal(ref);
+
+  return (
+    <div ref={ref}>
+      <button className="gallery-item" data-testid="item">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img alt="Gallery item" src="/img/a.webp" />
+      </button>
+    </div>
+  );
+}
+
+describe("useLoadedGalleryReveal", () => {
+  const animateMock = jest.fn();
+  const matchMediaMock = jest.fn().mockImplementation(() => ({
+    matches: false,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      writable: true,
+      value: animateMock,
+    });
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: matchMediaMock,
+    });
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    animateMock.mockReset();
+    matchMediaMock.mockClear();
+    matchMediaMock.mockImplementation(() => ({
+      matches: false,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    Object.defineProperty(HTMLImageElement.prototype, "complete", {
+      configurable: true,
+      get: () => true,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("animates already-loaded gallery items", async () => {
+    const { getByTestId } = render(<TestGallery />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => expect(animateMock).toHaveBeenCalled());
+    expect(getByTestId("item")).toHaveAttribute("data-reveal-animated", "true");
+  });
+
+  it("marks items as revealed without WAAPI motion when reduced motion is preferred", async () => {
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    const { getByTestId } = render(<TestGallery />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => expect(matchMediaMock).toHaveBeenCalled());
+    expect(animateMock).not.toHaveBeenCalled();
+    expect(getByTestId("item")).toHaveAttribute("data-reveal-animated", "true");
+  });
+});

--- a/src/hooks/__tests__/useProgressiveReveal.test.tsx
+++ b/src/hooks/__tests__/useProgressiveReveal.test.tsx
@@ -1,0 +1,202 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useRef } from "react";
+import { useProgressiveReveal } from "@/hooks/useProgressiveReveal";
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  observe = jest.fn();
+  disconnect = jest.fn();
+  unobserve = jest.fn();
+  static instances: MockIntersectionObserver[] = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  fire(entries: Partial<IntersectionObserverEntry>[]) {
+    this.callback(
+      entries as IntersectionObserverEntry[],
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+function TestGrid() {
+  const ref = useRef<HTMLDivElement>(null);
+  useProgressiveReveal(ref, ".reveal-target");
+
+  return (
+    <div ref={ref} data-testid="container">
+      <div className="reveal-target" data-testid="first" />
+      <div className="reveal-target" data-testid="second" />
+    </div>
+  );
+}
+
+describe("useProgressiveReveal", () => {
+  const animateMock = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      value: MockIntersectionObserver,
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      writable: true,
+      value: animateMock,
+    });
+  });
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    animateMock.mockReset();
+  });
+
+  it("keeps items visible by default instead of gating them behind reveal classes", () => {
+    const { getByTestId } = render(<TestGrid />);
+
+    expect(getByTestId("container")).not.toHaveAttribute("data-reveal-ready");
+    expect(getByTestId("first")).not.toHaveClass("reveal--visible");
+    expect(getByTestId("second")).not.toHaveClass("reveal--visible");
+  });
+
+  it("animates items that start within the reveal range", async () => {
+    const rectInRange = {
+      top: 120,
+      bottom: 320,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 120,
+      toJSON: () => ({}),
+    };
+
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => rectInRange as DOMRect);
+
+    render(<TestGrid />);
+
+    await waitFor(() => expect(animateMock).toHaveBeenCalled());
+  });
+
+  it("animates items once when they intersect later", () => {
+    const rectOutOfRange = {
+      top: 2000,
+      bottom: 2200,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 2000,
+      toJSON: () => ({}),
+    };
+
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => rectOutOfRange as DOMRect);
+
+    const { getByTestId } = render(<TestGrid />);
+    const target = getByTestId("second");
+
+    expect(animateMock).not.toHaveBeenCalled();
+
+    MockIntersectionObserver.instances[0].fire([
+      { isIntersecting: true, target } as Partial<IntersectionObserverEntry>,
+    ]);
+
+    expect(animateMock).toHaveBeenCalledTimes(1);
+
+    MockIntersectionObserver.instances[0].fire([
+      { isIntersecting: true, target } as Partial<IntersectionObserverEntry>,
+    ]);
+
+    expect(animateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rescans visible items after the page load event settles layout", () => {
+    const rectOutOfRange = {
+      top: 2000,
+      bottom: 2200,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 2000,
+      toJSON: () => ({}),
+    };
+    const rectInRange = {
+      top: 120,
+      bottom: 320,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 120,
+      toJSON: () => ({}),
+    };
+
+    const rectSpy = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => rectOutOfRange as DOMRect);
+
+    render(<TestGrid />);
+
+    expect(animateMock).not.toHaveBeenCalled();
+
+    rectSpy.mockImplementation(() => rectInRange as DOMRect);
+    window.dispatchEvent(new Event("load"));
+
+    expect(animateMock).toHaveBeenCalled();
+  });
+
+  it("rescans shortly after mount for masonry reflow changes", () => {
+    jest.useFakeTimers();
+
+    const rectOutOfRange = {
+      top: 2000,
+      bottom: 2200,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 2000,
+      toJSON: () => ({}),
+    };
+    const rectInRange = {
+      top: 120,
+      bottom: 320,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 120,
+      toJSON: () => ({}),
+    };
+
+    const rectSpy = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => rectOutOfRange as DOMRect);
+
+    render(<TestGrid />);
+    expect(animateMock).not.toHaveBeenCalled();
+
+    rectSpy.mockImplementation(() => rectInRange as DOMRect);
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(animateMock).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/src/hooks/__tests__/useProgressiveReveal.test.tsx
+++ b/src/hooks/__tests__/useProgressiveReveal.test.tsx
@@ -36,6 +36,16 @@ function TestGrid() {
 
 describe("useProgressiveReveal", () => {
   const animateMock = jest.fn();
+  const matchMediaMock = jest.fn().mockImplementation(() => ({
+    matches: false,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
 
   beforeAll(() => {
     Object.defineProperty(window, "IntersectionObserver", {
@@ -47,11 +57,27 @@ describe("useProgressiveReveal", () => {
       writable: true,
       value: animateMock,
     });
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: matchMediaMock,
+    });
   });
 
   beforeEach(() => {
     MockIntersectionObserver.instances = [];
     animateMock.mockReset();
+    matchMediaMock.mockClear();
+    matchMediaMock.mockImplementation(() => ({
+      matches: false,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
   });
 
   it("keeps items visible by default instead of gating them behind reveal classes", () => {
@@ -82,6 +108,40 @@ describe("useProgressiveReveal", () => {
     render(<TestGrid />);
 
     await waitFor(() => expect(animateMock).toHaveBeenCalled());
+  });
+
+  it("skips WAAPI motion when the user prefers reduced motion", async () => {
+    const rectInRange = {
+      top: 120,
+      bottom: 320,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 120,
+      toJSON: () => ({}),
+    };
+
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => rectInRange as DOMRect);
+
+    render(<TestGrid />);
+
+    await waitFor(() => expect(matchMediaMock).toHaveBeenCalled());
+    expect(animateMock).not.toHaveBeenCalled();
   });
 
   it("animates items once when they intersect later", () => {

--- a/src/hooks/useLoadedGalleryReveal.ts
+++ b/src/hooks/useLoadedGalleryReveal.ts
@@ -1,0 +1,60 @@
+import { RefObject, useEffect } from "react";
+import {
+  GALLERY_REVEAL_RESCAN_DELAY_MS,
+  REVEAL_BOTTOM_BUFFER_PX,
+  REVEAL_SIDE_BUFFER_PX,
+} from "@/lib/reveal-config";
+import { animateRevealElement, isElementWithinRevealRange } from "@/lib/reveal-helpers";
+
+/**
+ * Fail-open gallery motion.
+ *
+ * Galleries should not depend on viewport observers for visibility because
+ * masonry/CSS-column layout and image decode can settle late on Mobile Safari.
+ * Instead, content stays visible by default and tiles animate only when their
+ * image is already loaded.
+ */
+export function useLoadedGalleryReveal(ref: RefObject<Element | null>, selector = ".gallery-item img") {
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const animateLoadedItems = () => {
+      container.querySelectorAll<HTMLImageElement>(selector).forEach((img) => {
+        if (!img.complete) return;
+        const item = img.closest(".gallery-item");
+        if (!(item instanceof HTMLElement)) return;
+        if (!isElementWithinRevealRange(item)) return;
+        animateRevealElement(item);
+      });
+    };
+
+    const galleryItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".gallery-item")
+    );
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const item = entry.target as HTMLElement;
+          const img = item.querySelector<HTMLImageElement>("img");
+          if (img?.complete) animateRevealElement(item);
+        });
+      },
+      {
+        threshold: 0,
+        rootMargin: `${REVEAL_BOTTOM_BUFFER_PX}px ${REVEAL_SIDE_BUFFER_PX}px ${REVEAL_BOTTOM_BUFFER_PX}px ${REVEAL_SIDE_BUFFER_PX}px`,
+      }
+    );
+
+    galleryItems.forEach((item) => observer.observe(item));
+    animateLoadedItems();
+    const timeoutId = window.setTimeout(animateLoadedItems, GALLERY_REVEAL_RESCAN_DELAY_MS);
+
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(timeoutId);
+    };
+  }, [ref, selector]);
+}

--- a/src/hooks/useProgressiveReveal.ts
+++ b/src/hooks/useProgressiveReveal.ts
@@ -4,6 +4,8 @@ import {
   REVEAL_DURATION_MS,
   REVEAL_EASING,
   REVEAL_OFFSET_PX,
+  REVEAL_RESCAN_LONG_MS,
+  REVEAL_RESCAN_SHORT_MS,
   REVEAL_SIDE_BUFFER_PX,
 } from "@/lib/reveal-config";
 import { animateRevealElement } from "@/lib/reveal-helpers";
@@ -47,6 +49,12 @@ export function useProgressiveReveal(
   const offsetPx = options.offsetPx ?? DEFAULT_OPTIONS.offsetPx;
   const easing = options.easing ?? DEFAULT_OPTIONS.easing;
 
+  /**
+   * Use for teaser content that should feel scroll-aware, not for core gallery
+   * tiles. Teasers can animate on viewport entry; galleries need a load-aware
+   * path because late image/layout settlement on Safari previously caused hidden
+   * content bugs.
+   */
   useEffect(() => {
     const root = ref.current;
     if (!root) return;
@@ -61,6 +69,9 @@ export function useProgressiveReveal(
     if (items.length === 0) return;
 
     const scanVisibleItems = () => {
+      // Hydration and late card thumbnail sizing can shift teaser geometry
+      // after first paint. Re-scanning lets near-viewport cards still animate
+      // without ever hiding content if early geometry was incomplete.
       items.forEach((item) => {
         if (isWithinRevealRange(item.getBoundingClientRect(), resolvedOptions)) {
           animateRevealElement(item, resolvedOptions);
@@ -80,7 +91,7 @@ export function useProgressiveReveal(
       },
       {
         threshold: 0,
-        rootMargin: `0px ${resolvedOptions.sideBufferPx}px ${resolvedOptions.bottomBufferPx}px ${resolvedOptions.sideBufferPx}px`,
+        rootMargin: `${resolvedOptions.bottomBufferPx}px ${resolvedOptions.sideBufferPx}px ${resolvedOptions.bottomBufferPx}px ${resolvedOptions.sideBufferPx}px`,
       }
     );
 
@@ -89,9 +100,11 @@ export function useProgressiveReveal(
       observer.observe(item);
     });
 
+    // Short delayed passes catch late layout stabilization from image decode
+    // and static-export hydration without turning reveal into a correctness gate.
     const rescanTimeouts = [
-      window.setTimeout(scanVisibleItems, 180),
-      window.setTimeout(scanVisibleItems, 600),
+      window.setTimeout(scanVisibleItems, REVEAL_RESCAN_SHORT_MS),
+      window.setTimeout(scanVisibleItems, REVEAL_RESCAN_LONG_MS),
     ];
 
     window.addEventListener("load", scanVisibleItems);

--- a/src/hooks/useProgressiveReveal.ts
+++ b/src/hooks/useProgressiveReveal.ts
@@ -1,0 +1,107 @@
+import { RefObject, useEffect } from "react";
+import {
+  REVEAL_BOTTOM_BUFFER_PX,
+  REVEAL_DURATION_MS,
+  REVEAL_EASING,
+  REVEAL_OFFSET_PX,
+  REVEAL_SIDE_BUFFER_PX,
+} from "@/lib/reveal-config";
+import { animateRevealElement } from "@/lib/reveal-helpers";
+
+export interface ProgressiveRevealOptions {
+  bottomBufferPx?: number;
+  sideBufferPx?: number;
+  durationMs?: number;
+  offsetPx?: number;
+  easing?: string;
+}
+
+const DEFAULT_OPTIONS: Required<ProgressiveRevealOptions> = {
+  bottomBufferPx: REVEAL_BOTTOM_BUFFER_PX,
+  sideBufferPx: REVEAL_SIDE_BUFFER_PX,
+  durationMs: REVEAL_DURATION_MS,
+  offsetPx: REVEAL_OFFSET_PX,
+  easing: REVEAL_EASING,
+};
+
+function isWithinRevealRange(
+  rect: DOMRect,
+  options: Required<ProgressiveRevealOptions>
+) {
+  return (
+    rect.top < window.innerHeight + options.bottomBufferPx &&
+    rect.bottom > -options.bottomBufferPx &&
+    rect.left < window.innerWidth + options.sideBufferPx &&
+    rect.right > -options.sideBufferPx
+  );
+}
+
+export function useProgressiveReveal(
+  ref: RefObject<Element | null>,
+  selector: string,
+  options: ProgressiveRevealOptions = {}
+) {
+  const bottomBufferPx = options.bottomBufferPx ?? DEFAULT_OPTIONS.bottomBufferPx;
+  const sideBufferPx = options.sideBufferPx ?? DEFAULT_OPTIONS.sideBufferPx;
+  const durationMs = options.durationMs ?? DEFAULT_OPTIONS.durationMs;
+  const offsetPx = options.offsetPx ?? DEFAULT_OPTIONS.offsetPx;
+  const easing = options.easing ?? DEFAULT_OPTIONS.easing;
+
+  useEffect(() => {
+    const root = ref.current;
+    if (!root) return;
+    const resolvedOptions = {
+      bottomBufferPx,
+      sideBufferPx,
+      durationMs,
+      offsetPx,
+      easing,
+    };
+    const items = Array.from(root.querySelectorAll<HTMLElement>(selector));
+    if (items.length === 0) return;
+
+    const scanVisibleItems = () => {
+      items.forEach((item) => {
+        if (isWithinRevealRange(item.getBoundingClientRect(), resolvedOptions)) {
+          animateRevealElement(item, resolvedOptions);
+        }
+      });
+    };
+
+    scanVisibleItems();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          animateRevealElement(entry.target as HTMLElement, resolvedOptions);
+          observer.unobserve(entry.target);
+        });
+      },
+      {
+        threshold: 0,
+        rootMargin: `0px ${resolvedOptions.sideBufferPx}px ${resolvedOptions.bottomBufferPx}px ${resolvedOptions.sideBufferPx}px`,
+      }
+    );
+
+    items.forEach((item) => {
+      if (item.dataset.revealAnimated === "true") return;
+      observer.observe(item);
+    });
+
+    const rescanTimeouts = [
+      window.setTimeout(scanVisibleItems, 180),
+      window.setTimeout(scanVisibleItems, 600),
+    ];
+
+    window.addEventListener("load", scanVisibleItems);
+    window.addEventListener("resize", scanVisibleItems);
+
+    return () => {
+      observer.disconnect();
+      rescanTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
+      window.removeEventListener("load", scanVisibleItems);
+      window.removeEventListener("resize", scanVisibleItems);
+    };
+  }, [ref, selector, bottomBufferPx, sideBufferPx, durationMs, offsetPx, easing]);
+}

--- a/src/lib/__tests__/gallery-images.test.ts
+++ b/src/lib/__tests__/gallery-images.test.ts
@@ -120,6 +120,36 @@ describe("getGalleryImages() blur passthrough", () => {
     const result = getGalleryImages("test-project", "photography");
     expect(result[0].blur).toBeUndefined();
   });
+
+  it("includes intrinsic width and height from the medium WebP asset", () => {
+    const realFs = jest.requireActual("fs") as typeof import("fs");
+
+    (fs.readFileSync as jest.Mock).mockImplementation((filePath: string, encoding?: BufferEncoding) => {
+      if (typeof filePath === "string" && filePath.endsWith("images.json")) {
+        return JSON.stringify([{
+          basename: "photo-1",
+          thumb: "photo-1-320.webp",
+          md: "photo-dims-800.webp",
+          lg: "photo-dims-1600.webp",
+          original: "photo-1.jpg",
+        }]);
+      }
+
+      return realFs.readFileSync(
+        realFs.existsSync(filePath)
+          ? filePath
+          : "public/assets/photography/travel-photography/00002-800.webp",
+        encoding as BufferEncoding | undefined
+      );
+    });
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- fresh module instance needed for dimension-cache isolation
+      const { getGalleryImages: getIsolatedGalleryImages } = require("@/lib/gallery-images");
+      const result = getIsolatedGalleryImages("test-project", "photography");
+      expect(result[0]).toMatchObject({ width: 800, height: 540 });
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/gallery-images.ts
+++ b/src/lib/gallery-images.ts
@@ -6,6 +6,8 @@ export interface GalleryImage {
   alt: string;
   srcFull: string;
   blur?: string;
+  width?: number;
+  height?: number;
 }
 
 export interface SlideshowImage {
@@ -20,6 +22,60 @@ interface ImageManifestItem {
   lg: string | null;
   original: string | null;
   blur?: string;
+}
+
+const webpDimensionsCache = new Map<string, { width: number; height: number } | null>();
+
+function readWebPDimensions(filePath: string): { width: number; height: number } | undefined {
+  if (webpDimensionsCache.has(filePath)) {
+    return webpDimensionsCache.get(filePath) ?? undefined;
+  }
+
+  try {
+    const buffer = fs.readFileSync(filePath);
+    if (!Buffer.isBuffer(buffer)) {
+      webpDimensionsCache.set(filePath, null);
+      return undefined;
+    }
+
+    if (
+      buffer.toString("ascii", 0, 4) !== "RIFF" ||
+      buffer.toString("ascii", 8, 12) !== "WEBP"
+    ) {
+      webpDimensionsCache.set(filePath, null);
+      return undefined;
+    }
+
+    const chunkType = buffer.toString("ascii", 12, 16);
+    let dimensions: { width: number; height: number } | undefined;
+
+    if (chunkType === "VP8 ") {
+      dimensions = {
+        width: buffer.readUInt16LE(26) & 0x3fff,
+        height: buffer.readUInt16LE(28) & 0x3fff,
+      };
+    } else if (chunkType === "VP8L") {
+      const byte0 = buffer[21];
+      const byte1 = buffer[22];
+      const byte2 = buffer[23];
+      const byte3 = buffer[24];
+      dimensions = {
+        width: 1 + (((byte1 & 0x3f) << 8) | byte0),
+        height: 1 + (((byte3 & 0x0f) << 10) | (byte2 << 2) | ((byte1 & 0xc0) >> 6)),
+      };
+    } else if (chunkType === "VP8X") {
+      dimensions = {
+        width: 1 + buffer.readUIntLE(24, 3),
+        height: 1 + buffer.readUIntLE(27, 3),
+      };
+    }
+
+    webpDimensionsCache.set(filePath, dimensions ?? null);
+    return dimensions;
+  } catch {
+    webpDimensionsCache.set(filePath, null);
+    return undefined;
+  }
 }
 
 /**
@@ -96,9 +152,10 @@ export function getGalleryImages(
   return data
     .filter((item) => item.md)
     .map((item) => ({
-      src: `${baseUrl}/${item.md}`,
+      src: `${baseUrl}/${item.md!}`,
       alt: item.basename,
-      srcFull: item.lg ? `${baseUrl}/${item.lg}` : `${baseUrl}/${item.md}`,
+      srcFull: item.lg ? `${baseUrl}/${item.lg}` : `${baseUrl}/${item.md!}`,
+      ...readWebPDimensions(path.join(process.cwd(), "public", "assets", folder, slug, item.md!)),
       ...(item.blur ? { blur: item.blur } : {}),
     }));
 }

--- a/src/lib/reveal-config.ts
+++ b/src/lib/reveal-config.ts
@@ -5,12 +5,18 @@
  * - increase duration for slower/more relaxed motion
  * - decrease offset for subtler movement
  * - tweak easing for sharper/softer landing
+ * - increase gallery rescan delay if cached images reveal too early
  *
  * Used by:
  * - src/hooks/useProgressiveReveal.ts
+ * - src/hooks/useLoadedGalleryReveal.ts
  */
 export const REVEAL_DURATION_MS = 580;
 export const REVEAL_OFFSET_PX = 18;
 export const REVEAL_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
 export const REVEAL_BOTTOM_BUFFER_PX = 160;
 export const REVEAL_SIDE_BUFFER_PX = 50;
+export const REVEAL_START_OPACITY = 0.86;
+export const REVEAL_RESCAN_SHORT_MS = 180;
+export const REVEAL_RESCAN_LONG_MS = 600;
+export const GALLERY_REVEAL_RESCAN_DELAY_MS = 400;

--- a/src/lib/reveal-config.ts
+++ b/src/lib/reveal-config.ts
@@ -1,0 +1,16 @@
+/**
+ * Scroll-reveal tuning for progressive (fail-open) motion.
+ *
+ * Adjust these values to fine-tune the feel:
+ * - increase duration for slower/more relaxed motion
+ * - decrease offset for subtler movement
+ * - tweak easing for sharper/softer landing
+ *
+ * Used by:
+ * - src/hooks/useProgressiveReveal.ts
+ */
+export const REVEAL_DURATION_MS = 580;
+export const REVEAL_OFFSET_PX = 18;
+export const REVEAL_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+export const REVEAL_BOTTOM_BUFFER_PX = 160;
+export const REVEAL_SIDE_BUFFER_PX = 50;

--- a/src/lib/reveal-helpers.ts
+++ b/src/lib/reveal-helpers.ts
@@ -1,4 +1,27 @@
-import { REVEAL_DURATION_MS, REVEAL_EASING, REVEAL_OFFSET_PX } from "@/lib/reveal-config";
+import {
+  REVEAL_BOTTOM_BUFFER_PX,
+  REVEAL_DURATION_MS,
+  REVEAL_EASING,
+  REVEAL_OFFSET_PX,
+  REVEAL_SIDE_BUFFER_PX,
+  REVEAL_START_OPACITY,
+} from "@/lib/reveal-config";
+
+function prefersReducedMotion() {
+  return typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function isElementWithinRevealRange(item: HTMLElement) {
+  const rect = item.getBoundingClientRect();
+  return (
+    rect.top < window.innerHeight + REVEAL_BOTTOM_BUFFER_PX &&
+    rect.bottom > -REVEAL_BOTTOM_BUFFER_PX &&
+    rect.left < window.innerWidth + REVEAL_SIDE_BUFFER_PX &&
+    rect.right > -REVEAL_SIDE_BUFFER_PX
+  );
+}
 
 export function animateRevealElement(
   item: HTMLElement,
@@ -9,13 +32,18 @@ export function animateRevealElement(
   }
 ) {
   if (item.dataset.revealAnimated === "true") return;
-  item.dataset.revealAnimated = "true";
+      item.dataset.revealAnimated = "true";
 
-  if (typeof item.animate !== "function") return;
+  // Fail-open rule: content is already visible in base CSS/HTML. Animation is
+  // only polish. If WAAPI is unavailable or timing is odd, users still see the item.
+  if (prefersReducedMotion() || typeof item.animate !== "function") return;
 
   item.animate(
     [
-      { opacity: 0.86, transform: `translateY(${options?.offsetPx ?? REVEAL_OFFSET_PX}px)` },
+      {
+        opacity: REVEAL_START_OPACITY,
+        transform: `translateY(${options?.offsetPx ?? REVEAL_OFFSET_PX}px)`,
+      },
       { opacity: 1, transform: "translateY(0)" },
     ],
     {

--- a/src/lib/reveal-helpers.ts
+++ b/src/lib/reveal-helpers.ts
@@ -1,0 +1,27 @@
+import { REVEAL_DURATION_MS, REVEAL_EASING, REVEAL_OFFSET_PX } from "@/lib/reveal-config";
+
+export function animateRevealElement(
+  item: HTMLElement,
+  options?: {
+    durationMs?: number;
+    offsetPx?: number;
+    easing?: string;
+  }
+) {
+  if (item.dataset.revealAnimated === "true") return;
+  item.dataset.revealAnimated = "true";
+
+  if (typeof item.animate !== "function") return;
+
+  item.animate(
+    [
+      { opacity: 0.86, transform: `translateY(${options?.offsetPx ?? REVEAL_OFFSET_PX}px)` },
+      { opacity: 1, transform: "translateY(0)" },
+    ],
+    {
+      duration: options?.durationMs ?? REVEAL_DURATION_MS,
+      easing: options?.easing ?? REVEAL_EASING,
+      fill: "both",
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- harden the fail-open reveal architecture for cards and galleries
- make gallery reveal load-aware and viewport-aware so offscreen images do not animate too early
- pass intrinsic gallery image dimensions through from WebP assets to reduce late layout shifts on mobile
- add a shared glossary and update architecture/design/development docs to match the current motion model
- add a repo-local `caveman` skill under `.codex/skills/`

## Why
Mobile Safari exposed two different classes of issues:
- reveal timing could hide or mis-time motion
- gallery tiles could still feel like they loaded column-by-column because intrinsic dimensions were not reserved early enough

This PR keeps the fail-open safety rule while improving perceived loading stability and motion consistency.

## Key changes
- add `useLoadedGalleryReveal()` for gallery tiles
- centralize more reveal tuning constants in `src/lib/reveal-config.ts`
- add intrinsic `width` / `height` to gallery image data via `src/lib/gallery-images.ts`
- use intrinsic dimensions in `GalleryGrid` and `GallerySelection`
- tighten `RevealGrid` scope to teaser content only
- update docs and terminology: `fail-open motion`, `progressive reveal`, `load-triggered reveal`

## Verification
- `npx jest src/hooks/__tests__/useLoadedGalleryReveal.test.tsx src/hooks/__tests__/useProgressiveReveal.test.tsx src/components/gallery/__tests__/GalleryGrid.test.tsx src/components/download/__tests__/GallerySelection.test.tsx src/lib/__tests__/gallery-images.test.ts --runInBand`
- `npx eslint src/hooks/useLoadedGalleryReveal.ts src/hooks/__tests__/useLoadedGalleryReveal.test.tsx src/components/gallery/GalleryGrid.tsx src/components/download/GallerySelection.tsx src/components/gallery/__tests__/GalleryGrid.test.tsx src/components/download/__tests__/GallerySelection.test.tsx src/lib/gallery-images.ts src/lib/__tests__/gallery-images.test.ts src/lib/reveal-helpers.ts src/hooks/useProgressiveReveal.ts src/components/portfolio/RevealGrid.tsx src/lib/reveal-config.ts`
- `npm run type-check`

## Follow-up
Real-phone verification on iPhone Safari is still recommended before merge, especially on `/portfolio/photography/event-photography/`.
