### PR TITLE
Add lightweight quality harness docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+- what changed
+
+## Why
+
+- why this change exists
+
+## Acceptance Criteria
+
+List the concrete behaviors this slice needed to prove before implementation started.
+
+If this PR is tiny, docs-only, content-only, or mechanical maintenance, write `N/A` and say why.
+
+## Not In Scope
+
+- intentionally deferred work for this slice
+
+## Verification
+
+- [ ] `npm run check:pre-push`
+- [ ] targeted checks:
+- [ ] screenshots or manual UI checks if relevant
+
+## Learnings
+
+- what went well:
+- what went wrong:
+- discovered during verification:
+- guardrails added:
+- follow-ups:
+
+## Issue Closure
+
+If this PR should close an issue on merge to `main`, replace this line with a closing keyword such as `Fixes #51`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing
+
+Short guide for contributing without adding much process overhead. Use this file for the everyday workflow and see [docs/QUALITY-AND-DELIVERY.md](docs/QUALITY-AND-DELIVERY.md) for the fuller quality contract.
+
+## Default Workflow
+
+1. Start from an up-to-date `main`.
+2. Create a working branch.
+3. For non-trivial or risky work, write acceptance criteria before coding.
+4. Use TDD first or early when the change affects behavior, routing, schemas, SEO, deploy logic, or a bug fix.
+5. Run the narrowest relevant checks while working.
+6. Let the local hooks run before commit and push.
+7. Open a pull request, include issue-closing keywords when relevant, and squash merge.
+
+## Branch, PR, And Commit Naming
+
+- Branches:
+  - preferred: `codex/51-short-slug`
+  - if there is no issue yet: `codex/short-slug`
+- Pull request titles:
+  - preferred: `[#51] Add Food, Wasted project`
+  - if there is no issue yet: `Add Food, Wasted project`
+- Commit messages:
+  - keep them short and imperative
+  - issue numbers are useful context, but `#51` by itself only links an issue
+
+## Closing GitHub Issues Reliably
+
+GitHub reliably auto-closes issues when the merged pull request body or the final commit on the default branch uses a closing keyword such as:
+
+- `Fixes #51`
+- `Closes #51`
+- `Resolves #51`
+
+Recommended default: put `Fixes #51` in the PR body. That keeps the close behavior tied to the reviewed change, not to an intermediate local commit.
+
+## Tests And Validation
+
+- Required TDD:
+  - bug fixes
+  - behavior changes
+  - routing, sitemap, or SEO changes
+  - schema and content-model changes
+  - deploy or build-harness changes
+- Lighter workflow is fine for docs-only, content-only, and mechanical changes, but still run the relevant validation.
+- Before push, the canonical local gate is `npm run check:pre-push`.
+
+## Retrospectives
+
+For non-trivial slices, add short learnings either:
+
+- in the PR body under `Learnings`, or
+- in a dated note under `docs/retrospectives/` when the lesson is likely to matter again
+
+Keep it short:
+
+- what went well
+- what went wrong
+- discovered during verification
+- guardrails added
+- follow-ups
+
+## Merge Style
+
+- Prefer pull requests over direct pushes to `main`.
+- Prefer squash merge so `main` stays readable.
+- If repository settings are available, protect `main` and require PR-based merges.

--- a/README.md
+++ b/README.md
@@ -140,13 +140,16 @@ npm run dev
 ├── docs/                      # Developer & contributor documentation
 │   ├── GLOSSARY.md
 │   ├── ARCHITECTURE.md
+│   ├── QUALITY-AND-DELIVERY.md
 │   ├── DEVELOPMENT.md
 │   ├── DEPLOYMENT.md
 │   ├── ADDING-PROJECTS.md
 │   ├── REQUIREMENTS.md
 │   ├── DESIGN.md
 │   ├── IMPROVEMENTS.md
+│   ├── retrospectives/
 │   └── MIGRATION-PROGRESS.md
+├── CONTRIBUTING.md            # Lightweight branch / PR / quality workflow
 ├── Jinee_website/             # Original site (kept as reference)
 ├── next.config.ts
 ├─ postcss.config.mjs
@@ -161,10 +164,12 @@ npm run dev
 |----------|----------|---------|
 | [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md) | **New developers** | Complete beginner's guide — zero-knowledge intro to the tech stack, first-time setup, and day-to-day workflow |
 | [docs/GLOSSARY.md](docs/GLOSSARY.md) | Everyone | Shared vocabulary for repo-specific terms, motion patterns, and gallery concepts |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributors | Fast path for branch naming, PR flow, issue closing, testing, and merge conventions |
 | [docs/REQUIREMENTS.md](docs/REQUIREMENTS.md) | Developers / PMs | Functional and non-functional requirements; deferred items |
 | [docs/DESIGN.md](docs/DESIGN.md) | Developers | Detailed software design: modules, data model, algorithms, security, testing |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Developers | Component hierarchy, data flow, image pipeline, PHP endpoints |
 | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Developers | Full local setup, running PHP side-by-side, debugging |
+| [docs/QUALITY-AND-DELIVERY.md](docs/QUALITY-AND-DELIVERY.md) | Contributors | Lightweight quality harness: branches, PRs, hooks, TDD expectations, and retrospectives |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Developers | FTP build & deploy, `.htaccess` redirects, smoke test |
 | [docs/ADDING-PROJECTS.md](docs/ADDING-PROJECTS.md) | Content editors | Step-by-step guide for adding new portfolio projects |
 | [docs/IMPROVEMENTS.md](docs/IMPROVEMENTS.md) | Developers | Completed backlog items and deferred items summary |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -269,6 +269,8 @@ Before every `git push`, Husky runs `npm run check:pre-push` locally:
 
 This catches the expensive failures locally to save GitHub Actions minutes. It is still a local hook, so `git push --no-verify` can bypass it; the deploy workflow keeps remote build/output verification as a backstop.
 
+For the broader workflow around branch naming, PR issue-closing keywords, TDD expectations, and lightweight retrospectives, see [../CONTRIBUTING.md](../CONTRIBUTING.md) and [QUALITY-AND-DELIVERY.md](QUALITY-AND-DELIVERY.md).
+
 ---
 
 ## Code Style

--- a/docs/QUALITY-AND-DELIVERY.md
+++ b/docs/QUALITY-AND-DELIVERY.md
@@ -1,0 +1,120 @@
+# Quality And Delivery
+
+This repo should have useful guardrails without turning every change into a ceremony. The goal is high confidence with low drag.
+
+## Principles
+
+- keep slices small enough to review clearly
+- automate stable checks, not every idea
+- prefer local fast feedback over burning remote CI minutes
+- use more process only when the risk actually rises
+- capture surprises found during verification so the next slice starts smarter
+
+## Branch And Pull Request Contract
+
+- Prefer one branch per issue:
+  - `codex/51-short-slug`
+- If there is no issue yet, use:
+  - `codex/short-slug`
+- Prefer one pull request per issue or slice.
+- Prefer squash merge into `main`.
+- When a PR should close an issue, put a closing keyword in the PR body:
+  - `Fixes #51`
+
+Plain `#51` is still useful for linking context, but it should not be treated as the reliable auto-close mechanism.
+
+## Local Quality Gates
+
+Current local hooks are the main quality harness:
+
+- `pre-commit` runs `npm run check:pre-commit`
+  - `lint-staged`
+  - related Jest tests for staged TS and TSX files
+  - manifest validation
+- `pre-push` runs `npm run check:pre-push`
+  - full lint
+  - full Jest suite
+  - manifest validation
+  - `next build`
+
+Remote safety net:
+
+- the deploy workflow still verifies the build output on GitHub
+- local hooks can be bypassed with `--no-verify`, so they are guardrails, not enforcement
+
+## TDD And Review Expectations
+
+Use TDD first or early for:
+
+- bug fixes
+- behavior changes
+- routing, sitemap, and SEO changes
+- schema or content-model changes
+- build, deploy, or hook changes
+
+For content-only, docs-only, or mechanical changes:
+
+- do not force fake TDD
+- do run the relevant validation
+- do check for drift in docs, routes, and manifests when applicable
+
+For risky changes, add one adversarial review pass before merge. Ask:
+
+- what breaks if data is missing, hidden, or placeholder
+- what breaks if a route no longer exists
+- what breaks if a slow or remote dependency is unavailable
+- what breaks if a local hook is bypassed
+
+## Acceptance Criteria
+
+Write acceptance criteria up front when the slice is:
+
+- non-trivial
+- user-facing
+- risky
+- architectural
+- performance-sensitive
+
+Skip the ceremony for typo-only, docs-only, or clearly mechanical maintenance.
+
+## Verification Cadence
+
+- run the narrowest relevant tests first while coding
+- rerun only impacted checks during iteration
+- use `npm run check:pre-push` before push or PR, not after every tiny edit
+- keep manual verification focused on the changed surface area
+
+Fast feedback beats repeatedly paying the full-suite cost.
+
+## Retrospectives And Learnings
+
+For non-trivial slices, record short learnings either in the PR body or in `docs/retrospectives/`.
+
+Use this shape:
+
+- what went well
+- what went wrong
+- discovered during verification
+- guardrails added
+- follow-ups
+
+Retrospectives should stay brief. If a lesson does not affect future work, do not turn it into a permanent process rule.
+
+## Definition Of Done
+
+A slice is done when:
+
+- the intended scope is complete
+- relevant tests or validation passed
+- docs were updated if behavior or workflow changed
+- obvious dead links, dead routes, or config drift were checked
+- meaningful tradeoffs or follow-ups are noted
+
+## Repository Settings To Prefer
+
+If GitHub repository settings are available, prefer:
+
+- protect `main`
+- merge through pull request
+- prefer squash merge
+- require review or explicit self-check notes when remote CI minutes are constrained

--- a/docs/retrospectives/TEMPLATE.md
+++ b/docs/retrospectives/TEMPLATE.md
@@ -1,0 +1,31 @@
+# Retrospective Template
+
+Use this for non-trivial slices when the learnings are worth keeping beyond a single PR body.
+
+## Metadata
+
+- Date:
+- Issue:
+- Branch:
+- PR:
+- Scope:
+
+## What Went Well
+
+- ...
+
+## What Went Wrong
+
+- ...
+
+## Discovered During Verification
+
+- ...
+
+## Guardrails Added
+
+- ...
+
+## Follow-Ups
+
+- ...


### PR DESCRIPTION
## What changed
- added a lightweight `CONTRIBUTING.md` with branch, PR, issue-closing, TDD, and merge conventions
- added a pull request template with summary, acceptance criteria, verification, and learnings sections
- added `docs/QUALITY-AND-DELIVERY.md` to document the repo's local quality harness and low-overhead process rules
- added a retrospective template for non-trivial slices
- linked the new process docs from the README and development guide

## Why
The repo already has useful technical checks, but the day-to-day workflow was still living mostly in conversation. This change makes the branch and PR flow, issue-closing behavior, and learnings/retrospective practice explicit without adding heavy ceremony.

## Impact
Contributors now have one clear path for how to branch, test, publish, and capture learnings, and the GitHub PR flow now has a built-in template that nudges the right information into each change.

## Validation
- `npm run validate:manifests`
- `npm run check:pre-push`
